### PR TITLE
TOML template upgrade and various code improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ For more detailed dnscrypt proxy configuration please study and modify the *dnsc
 
 ----
 
-None.
+`ansible.utilsa collection is required for this role to work.
+
+```bash
+ansible-galaxy collection install ansible.utils
+```
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ For more detailed dnscrypt proxy configuration please study and modify the *dnsc
 | `dnscrypt_force_tcp` | Always use TCP to connect to upstream servers. Useful for TOR. | `'false'` |
 | `dnscrypt_fallback_resolver` | non-encrypted fallback resolver. Only used if DNS config doesn't work. `114.114.114.114:53` for people in China | `9.9.9.9:5` |
 | `dnscrypt_server_names` | List of upstream servers to use. See server_names option in dnscrypt-proxy documentation |
+| `dnscrypt_anonymizer_server_names` | List of anonymizer servers to use | `[]` |
+| `dnscrypt_bootstrap_resolvers` | List of bootstrap resolvers | `['9.9.9.9:53', '8.8.8.8:53']` |
+| `dnscrypt_cache_size` | Size of the DNS cache | `4096` |
+| `dnscrypt_cache_min_ttl` | Minimum TTL for cached entries | `2400` |
+| `dnscrypt_ignore_system_dns` | Ignore system DNS settings | `'false'` |
+| `dnscrypt_netprobe_timeout` | Maximum time to wait for network connectivity before initializing the proxy | `60` |
+| `dnscrypt_netprobe_address` | Address to probe for network connectivity | `'9.9.9.9:53'` |
 
 Dependencies
 ----

--- a/README.md
+++ b/README.md
@@ -3,36 +3,40 @@
 [![MIT licensed][mit-badge]][mit-link]
 [![Galaxy Role][role-badge]][galaxy-link]
 
-DEPRECATION NOTICE
+## DEPRECATION NOTICE
+
 ----
 
-*(Left here for reference only)*
+> *(Left here for reference only)*
 
-Description
+## Description
+
 ----
 
 Ansible role which installs and configures [DNSCrypt-proxy2][dnscrypt-proxy2-link].
 
 The role achieves the following:
 
- - Installs dnscrypt-proxy 2
- - Configures dnscrypt-proxy to be run as unprivileged user [ for security purposes ]
- - If distro uses systemd init: configures systemd socket activated dnscrypt-proxy.service
- - If distro does not use systemd: configures built in dnscrypt-proxy service
+- Installs dnscrypt-proxy 2
+- Configures dnscrypt-proxy to be run as unprivileged user [ for security purposes ]
+- If distro uses systemd init: configures systemd socket activated dnscrypt-proxy.service
+- If distro does not use systemd: configures built in dnscrypt-proxy service
 
-Requirements
-------------
+## Requirements
+
+----
 
 NOTE: Role requires Fact Gathering by ansible!
 
 One of the following distros (or derivatives) required:
 
- - Debian | Raspbian | [Minibian][minibian-link]
-    - jessie
-    - stretch
+- Debian | Raspbian | [Minibian][minibian-link]
+  - jessie
+  - stretch
 
-Role Variables
---------------
+## Role Variables
+
+----
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -71,26 +75,33 @@ For more detailed dnscrypt proxy configuration please study and modify the *dnsc
 | `dnscrypt_netprobe_timeout` | Maximum time to wait for network connectivity before initializing the proxy | `60` |
 | `dnscrypt_netprobe_address` | Address to probe for network connectivity | `'9.9.9.9:53'` |
 
-Dependencies
+## Dependencies
+
 ----
 
 None.
 
-Example Playbook
+## Example Playbook
+
 ----
 
 ```yaml
 - hosts: raspberrypi
   gather_facts: yes
+  become: yes
   roles: drew-kun.dnscrypt
 ```
 
-License
+> the role requires privilege escalation with `become: yes`
+
+## License
+
 ----
 
 [MIT][mit-link]
 
-Author Information
+## Author Information
+
 ----
 
 Andrew Shagayev | [e-mail](mailto:drewshg@gmail.com)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,13 +16,12 @@ dnscrypt_arch: { archive: linux_arm64, dir: linux-arm64 }
 
 dnscrypt_default_version: 2.0.17 # Fallback version in case the website doesn't have info about latest version
 
-dnscrypt_on_pihole: no      # Is it dnscrypt on pihole installation? Will modify pihole config
+dnscrypt_on_pihole: false      # Is it dnscrypt on pihole installation? Will modify pihole config
 
 dnscrypt_bin: /usr/local/bin/dnscrypt-proxy  # where to put dnscrypt binary
 dnscrypt_config: /etc/dnscrypt-proxy/dnscrypt-proxy.toml # where to store dnscrypt config
 
-dnscrypt_sysd_socket_only: yes  # Use ONLY Systemd socket activation of dnscrypt-proxy.service (used in dnscrypt-proxy.toml)
-
+dnscrypt_sysd_socket_only: true  # Use ONLY Systemd socket activation of dnscrypt-proxy.service (used in dnscrypt-proxy.toml)
 
 # DNSCrypt main configruation file variables (Check templates/dnscrypt-proxy.toml.j2)
 dnscrypt_ipv4_address: 127.0.0.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ dnscrypt_require_dnssec: 'true'    # Requre upstream resolver to support DNSSEC 
 dnscrypt_require_nolog: 'true'     # Server must not log user queries (declarative).
 dnscrypt_require_nofilter: 'true'  # Server must not enforce its own blacklist (for parental control, ads blocking)
 dnscrypt_force_tcp: 'false'        # Always use TCP to connect to upstream servers. Useful for TOR. Otherwise use 'false'
-dnscrypt_lb_strategy: 'p2'         # Load balancing strategy. 'p2' is the default, 'ph' is the other option.
+dnscrypt_lb_strategy: "'p2'"         # Load balancing strategy. 'p2' is the default, 'ph' is the other option.
 dnscrypt_lb_estimator: "true"
 
 dnscrypt_server_names: # Optional list of servers to use. See https://dnscrypt.info/public-servers for the values.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,8 +43,11 @@ dnscrypt_server_names: # Optional list of servers to use. See https://dnscrypt.i
 dnscrypt_anonymizer_server_names: # Optional list of anonymizer servers to use. See https://dnscrypt.info/public-servers for the values.
 # 9.9.9.9:53 -- Quad9 DNSSec anycast privacy oriented Google alternative
 # 114.114.114.114:53 -- for people in China.
+
+# fallback_resolver was deprecated in version 2.0.38. Use bootstrap_resolvers instead.
 dnscrypt_bootstrap_resolvers: ['9.9.9.9:53', '8.8.8.8:53']
-dnscrypt_fallback_resolver: 9.9.9.9:53 # non-encrypted fallback resolver. Only used if DNS config doesn't work
+dnscrypt_fallback_resolver: "{{ dnscrypt_bootstrap_resolvers[0] }}" # non-encrypted fallback resolver. Only used if DNS config doesn't work
+
 dnscrypt_ignore_system_dns: 'false'
 dnscrypt_netprobe_address: '9.9.9.9:53'
 dnscrypt_cache_size: 4096

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,10 +36,17 @@ dnscrypt_require_dnssec: 'true'    # Requre upstream resolver to support DNSSEC 
 dnscrypt_require_nolog: 'true'     # Server must not log user queries (declarative).
 dnscrypt_require_nofilter: 'true'  # Server must not enforce its own blacklist (for parental control, ads blocking)
 dnscrypt_force_tcp: 'false'        # Always use TCP to connect to upstream servers. Useful for TOR. Otherwise use 'false'
+dnscrypt_lb_strategy: 'p2'         # Load balancing strategy. 'p2' is the default, 'ph' is the other option.
+dnscrypt_lb_estimator: "true"
 
 dnscrypt_server_names: # Optional list of servers to use. See https://dnscrypt.info/public-servers for the values.
-
+dnscrypt_anonymizer_server_names: # Optional list of anonymizer servers to use. See https://dnscrypt.info/public-servers for the values.
 # 9.9.9.9:53 -- Quad9 DNSSec anycast privacy oriented Google alternative
 # 114.114.114.114:53 -- for people in China.
-dnscrypt_fallback_resolver: 9.9.9.9:53 # non-encrypted fallback resolver. Only used if DNS config doesn't work
-...
+dnscrypt_bootstrap_resolvers: ['9.9.9.9:53', '8.8.8.8:53']
+# dnscrypt_fallback_resolver: 9.9.9.9:53 # non-encrypted fallback resolver. Only used if DNS config doesn't work
+dnscrypt_ignore_system_dns: 'false'
+dnscrypt_netprobe_address: '9.9.9.9:53'
+dnscrypt_cache_size: 4096
+dnscrypt_cache_min_ttl: 2400
+dnscrypt_timeout: 5000

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ dnscrypt_anonymizer_server_names: # Optional list of anonymizer servers to use. 
 # 9.9.9.9:53 -- Quad9 DNSSec anycast privacy oriented Google alternative
 # 114.114.114.114:53 -- for people in China.
 dnscrypt_bootstrap_resolvers: ['9.9.9.9:53', '8.8.8.8:53']
-# dnscrypt_fallback_resolver: 9.9.9.9:53 # non-encrypted fallback resolver. Only used if DNS config doesn't work
+dnscrypt_fallback_resolver: 9.9.9.9:53 # non-encrypted fallback resolver. Only used if DNS config doesn't work
 dnscrypt_ignore_system_dns: 'false'
 dnscrypt_netprobe_address: '9.9.9.9:53'
 dnscrypt_cache_size: 4096

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,14 +6,12 @@
   ansible.builtin.service:
     name: pihole-FTL
     state: restarted
-  become: true
   when: dnscrypt_on_pihole
 
 # No SystemD
 - name: Run 'dnscrypt-proxy -service restart'
   ansible.builtin.command:
     cmd: "{{ dnscrypt_bin }} -service restart"
-  become: true
   changed_when: false
   when: not dnscrypt_systemd.stat.exists
 
@@ -22,7 +20,6 @@
   ansible.builtin.command:
     cmd: "{{ dnscrypt_bin }} -service stop"
     creates: /var/run/dnscrypt-proxy.pid
-  become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
   when: dnscrypt_systemd.stat.exists
 
@@ -30,14 +27,12 @@
   ansible.builtin.service:
     name: dnscrypt-proxy.service
     state: stopped
-  become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
   when: dnscrypt_systemd.stat.exists
 
 - name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: true
-  become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
   when: dnscrypt_systemd.stat.exists
 
@@ -46,7 +41,6 @@
     name: dnscrypt-proxy.socket
     enabled: true
     state: restarted
-  become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
   when: dnscrypt_systemd.stat.exists
 ...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,20 +9,22 @@
   become: true
   when: dnscrypt_on_pihole
 
-- name: Restart dnscrypt-proxy service
-  ansible.builtin.service:
-    name: dnscrypt-proxy
-    state: restarted
-  when: not dnscrypt_systemd.stat.exists
+# No SystemD
+- name: Run 'dnscrypt-proxy -service restart'
+  ansible.builtin.command:
+    cmd: "{{ dnscrypt_bin }} -service restart"
   become: true
+  changed_when: false
+  when: not dnscrypt_systemd.stat.exists
 
-- name: Stop dnscrypt-proxy service
-  ansible.builtin.service:
-    name: dnscrypt-proxy
-    state: stopped
+# SystemD
+- name: Make sure built-in dnscrypt-proxy service is stopped, running 'dnscrypt-proxy -service stop'
+  ansible.builtin.command:
+    cmd: "{{ dnscrypt_bin }} -service stop"
+    creates: /var/run/dnscrypt-proxy.pid
   become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
-  when: dnscrypt_systemd.stat.exists
+  when: not dnscrypt_systemd.stat.exists
 
 - name: Make sure dnscrypt-proxy.service is stopped before restarting dnscrypt-proxy.socket
   ansible.builtin.service:
@@ -30,6 +32,7 @@
     state: stopped
   become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
+  when: dnscrypt_systemd.stat.exists
 
 - name: Reload systemd daemon
   ansible.builtin.systemd:
@@ -46,12 +49,4 @@
   become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
   when: dnscrypt_systemd.stat.exists
-
-- name: Restart dnscrypt-proxy.socket
-  ansible.builtin.service:
-    name: dnscrypt-proxy.socket
-    enabled: true
-    state: restarted
-  become: true
-  listen: Restart dnscrypt-proxy.socket systemd unit
-  when: dnscrypt_systemd.stat.exists
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,38 +3,55 @@
 
 # DNSMasq
 - name: Restart pihole-FTL
-  service: name=pihole-FTL state=restarted
-  become: yes
+  ansible.builtin.service:
+    name: pihole-FTL
+    state: restarted
+  become: true
   when: dnscrypt_on_pihole
 
-# No SystemD
-- name: Run 'dnscrypt-proxy -service restart'
-  command: "{{ dnscrypt_bin }} -service restart"
-  become: yes
+- name: Restart dnscrypt-proxy service
+  ansible.builtin.service:
+    name: dnscrypt-proxy
+    state: restarted
   when: not dnscrypt_systemd.stat.exists
+  become: true
 
-# SystemD
-- name: Make sure built-in dnscrypt-proxy service is stopped, runing 'dnscrypt-proxy -service stop'
-  command: "{{ dnscrypt_bin }} -service stop"
-  become: yes
+- name: Stop dnscrypt-proxy service
+  ansible.builtin.service:
+    name: dnscrypt-proxy
+    state: stopped
+  become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
   when: dnscrypt_systemd.stat.exists
 
 - name: Make sure dnscrypt-proxy.service is stopped before restarting dnscrypt-proxy.socket
-  service: name=dnscrypt-proxy.service state=stopped
-  become: yes
+  ansible.builtin.service:
+    name: dnscrypt-proxy.service
+    state: stopped
+  become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
-  when: dnscrypt_systemd.stat.exists
 
 - name: Reload systemd daemon
-  systemd: daemon_reload=yes
-  become: yes
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
   when: dnscrypt_systemd.stat.exists
 
 - name: Restart dnscrypt-proxy.socket
-  service: name=dnscrypt-proxy.socket enabled=yes state=restarted
-  become: yes
+  ansible.builtin.service:
+    name: dnscrypt-proxy.socket
+    enabled: true
+    state: restarted
+  become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
   when: dnscrypt_systemd.stat.exists
-...
+
+- name: Restart dnscrypt-proxy.socket
+  ansible.builtin.service:
+    name: dnscrypt-proxy.socket
+    enabled: true
+    state: restarted
+  become: true
+  listen: Restart dnscrypt-proxy.socket systemd unit
+  when: dnscrypt_systemd.stat.exists

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -24,7 +24,7 @@
     creates: /var/run/dnscrypt-proxy.pid
   become: true
   listen: Restart dnscrypt-proxy.socket systemd unit
-  when: not dnscrypt_systemd.stat.exists
+  when: dnscrypt_systemd.stat.exists
 
 - name: Make sure dnscrypt-proxy.service is stopped before restarting dnscrypt-proxy.socket
   ansible.builtin.service:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
-
-  name: dnscrypt
+galaxy_info:
+  role_name: dnscrypt
   author: Andrew Shagayev
   description: Role for automated dnscrypt-proxy2 installation
 
@@ -23,7 +23,3 @@
     - dnscrypt
     - proxy
     - proxy2
-
-  collections:
-    - name: "ansible.utils"
-      version: ">=4.1.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,3 +23,7 @@ galaxy_info:
     - dnscrypt
     - proxy
     - proxy2
+
+  collections:
+    - name: "ansible.utils"
+      version: ">=4.1.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 ---
-galaxy_info:
+
   role_name: dnscrypt
   author: Andrew Shagayev
   description: Role for automated dnscrypt-proxy2 installation
@@ -23,3 +23,6 @@ galaxy_info:
     - dnscrypt
     - proxy
     - proxy2
+
+  dependencies:
+    "ansible.utils": ">=4.1.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,19 +6,20 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 1.2
+  min_ansible_version: '1.2'
 
   github_branch: master
 
+  namespace: dnscrypt
+
   platforms:
-  - name: Debian
-    versions:
-    - stretch
+    - name: Debian
+      versions:
+        - stretch
 
   galaxy_tags:
-  - networking
-  - dns
-  - dnscrypt
-  - proxy
-  - proxy2
-...
+    - networking
+    - dns
+    - dnscrypt
+    - proxy
+    - proxy2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,4 +25,5 @@
     - proxy2
 
   dependencies:
-    "ansible.utils": ">=4.1.0"
+    name: "ansible.utils"
+    version: ">=4.1.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 
-  role_name: dnscrypt
+  name: dnscrypt
   author: Andrew Shagayev
   description: Role for automated dnscrypt-proxy2 installation
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,6 @@
     - proxy
     - proxy2
 
-  dependencies:
+  collections:
     - name: "ansible.utils"
       version: ">=4.1.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,5 +25,5 @@
     - proxy2
 
   dependencies:
-    name: "ansible.utils"
-    version: ">=4.1.0"
+    - name: "ansible.utils"
+      version: ">=4.1.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,7 +23,3 @@ galaxy_info:
     - dnscrypt
     - proxy
     - proxy2
-
-  collections:
-    - name: "ansible.utils"
-      version: ">=4.1.0"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,7 +7,6 @@
   with_items:
     - "{{ config_prefix | default('/') }}etc/dnscrypt-proxy/"
     - /opt/dnscrypt-proxy/
-  become: true
   tags:
     - dnscrypt
     - dnscrypt_install
@@ -65,7 +64,6 @@
     remote_src: true
     src: "{{ item['browser_download_url'] }}"
     dest: /opt/dnscrypt-proxy
-  become: true
   no_log: true  # prevent huge green or yellow output
   with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
   when: dnscrypt_arch.archive in item.name and not item.name.endswith("minisig")
@@ -81,7 +79,6 @@
     src: "/opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
     dest: "{{ dnscrypt_bin }}"
     state: link
-  become: true
   tags:
     - dnscrypt
     - dnscrypt_install
@@ -89,7 +86,6 @@
 - name: "[install] Check dnscrypt-proxy binary capabilities for running it as unprivileged user"
   ansible.builtin.command:
     cmd: "setcap -v cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
-  become: true
   changed_when: false
   failed_when: false
   register: dnscrypt_bin_cap
@@ -100,7 +96,6 @@
 - name: "[install] Fix dnscrypt-proxy binary capabilities for running it as unprivileged user"
   ansible.builtin.command:
     cmd: "setcap cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
-  become: true
   when: dnscrypt_bin_cap.rc != 0
   changed_when: false
   tags:
@@ -112,7 +107,6 @@
     src: dnscrypt-proxy.toml.j2
     dest: "{{ dnscrypt_config }}"
     mode: '0644'
-  become: true
   notify:
     - Restart dnscrypt-proxy.socket systemd unit
     - Run 'dnscrypt-proxy -service restart'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,40 +6,40 @@
   block:
     - name: "[install] Ensure that the required directories exist"
       ansible.builtin.file:
-      path: "{{ item }}"
-      state: directory
-      mode: '0755'
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
       with_items:
         - "{{ config_prefix | default('/') }}etc/dnscrypt-proxy/"
         - /opt/dnscrypt-proxy/
 
     - name: "[install] Retrieve the latest dnscrypt-proxy versions for all architectures"
       ansible.builtin.uri:
-      url: https://api.github.com/repos/jedisct1/dnscrypt-proxy/releases/latest
+        url: https://api.github.com/repos/jedisct1/dnscrypt-proxy/releases/latest
       register: dnscrypt_latest_all_arch
       ignore_errors: true
 
     - name: "[install] Set default dnscrypt-proxy assets only if failed retrieving the latest version"
       ansible.builtin.set_fact:
-      dnscrypt_latest_all_arch:
-        failed: true
-        json:
-          assets:
-            - name: "dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
-              browser_download_url:
-                "https://github.com/jedisct1/dnscrypt-proxy/releases/download/\
-                {{ dnscrypt_default_version }}/\
-                dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
+        dnscrypt_latest_all_arch:
+          failed: true
+          json:
+            assets:
+              - name: "dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
+                browser_download_url:
+                  "https://github.com/jedisct1/dnscrypt-proxy/releases/download/\
+                  {{ dnscrypt_default_version }}/\
+                  dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
       when: dnscrypt_latest_all_arch.failed
 
     - name: "[install] Fall back to default dnscrypt-proxy version: {{ dnscrypt_default_version }}"
       ansible.builtin.set_fact:
-      dnscrypt_latest_version: "{{ dnscrypt_default_version }}"
+        dnscrypt_latest_version: "{{ dnscrypt_default_version }}"
       when: dnscrypt_latest_all_arch.failed
 
     - name: "[install] Find the latest dnscrypt-proxy version for architecture {{ dnscrypt_arch.archive }} "
       ansible.builtin.set_fact:
-      dnscrypt_latest_version: "{{ item['browser_download_url'].split('/')[7] }}"
+        dnscrypt_latest_version: "{{ item['browser_download_url'].split('/')[7] }}"
       with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
       no_log: true  # prevent huge green or yellow output
       when:
@@ -49,9 +49,9 @@
 
     - name: "[install] Download dnscrypt-proxy version: {{ dnscrypt_latest_version }}"
       ansible.builtin.unarchive:
-      remote_src: true
-      src: "{{ item['browser_download_url'] }}"
-      dest: /opt/dnscrypt-proxy
+        remote_src: true
+        src: "{{ item['browser_download_url'] }}"
+        dest: /opt/dnscrypt-proxy
       no_log: true  # prevent huge green or yellow output
       with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
       when: dnscrypt_arch.archive in item.name and not item.name.endswith("minisig")
@@ -61,28 +61,28 @@
 
     - name: "[install] Symlink binary {{ dnscrypt_bin }}"
       ansible.builtin.file:
-      src: "/opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
-      dest: "{{ dnscrypt_bin }}"
-      state: link
+        src: "/opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+        dest: "{{ dnscrypt_bin }}"
+        state: link
 
     - name: "[install] Check dnscrypt-proxy binary capabilities for running it as unprivileged user"
       ansible.builtin.command:
-      cmd: "setcap -v cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+        cmd: "setcap -v cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
       changed_when: false
       failed_when: false
       register: dnscrypt_bin_cap
 
     - name: "[install] Fix dnscrypt-proxy binary capabilities for running it as unprivileged user"
       ansible.builtin.command:
-      cmd: "setcap cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+        cmd: "setcap cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
       when: dnscrypt_bin_cap.rc != 0
       changed_when: false
 
     - name: "[install] Generate dnscrypt-proxy.toml configuration file"
       ansible.builtin.template:
-      src: dnscrypt-proxy.toml.j2
-      dest: "{{ dnscrypt_config }}"
-      mode: '0644'
+        src: dnscrypt-proxy.toml.j2
+        dest: "{{ dnscrypt_config }}"
+        mode: '0644'
       notify:
         - Restart dnscrypt-proxy.socket systemd unit
         - Run 'dnscrypt-proxy -service restart'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,112 +1,121 @@
 ---
 - name: "[install] Ensure that the required directories exist"
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    mode: '0755'
   with_items:
-  - "{{ config_prefix|default('/') }}etc/dnscrypt-proxy/"
-  - /opt/dnscrypt-proxy/
-  become: yes
+    - "{{ config_prefix | default('/') }}etc/dnscrypt-proxy/"
+    - /opt/dnscrypt-proxy/
+  become: true
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
-- name: "[install] Retrive the latest dnscrypt-proxy versions for all architectures"
-  uri:
+- name: "[install] Retrieve the latest dnscrypt-proxy versions for all architectures"
+  ansible.builtin.uri:
     url: https://api.github.com/repos/jedisct1/dnscrypt-proxy/releases/latest
   register: dnscrypt_latest_all_arch
   ignore_errors: true
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
 - name: "[install] Set default dnscrypt-proxy assets only if failed retrieving the latest version"
-  set_fact:
+  ansible.builtin.set_fact:
     dnscrypt_latest_all_arch:
       failed: true
       json:
         assets:
-        - name: "dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
-          browser_download_url:
-            "https://github.com/jedisct1/dnscrypt-proxy/releases/download/\
-            {{ dnscrypt_default_version }}/\
-            dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
+          - name: "dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
+            browser_download_url:
+              "https://github.com/jedisct1/dnscrypt-proxy/releases/download/\
+              {{ dnscrypt_default_version }}/\
+              dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
   when: dnscrypt_latest_all_arch.failed
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
 - name: "[install] Fall back to default dnscrypt-proxy version: {{ dnscrypt_default_version }}"
-  set_fact:
+  ansible.builtin.set_fact:
     dnscrypt_latest_version: "{{ dnscrypt_default_version }}"
   when: dnscrypt_latest_all_arch.failed
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
-- name: "[install] Find the latest dnscrypt-proxy version for {{ dnscrypt_arch.archive }} architecture (no_log: yes)"
-  set_fact:
+- name: "[install] Find the latest dnscrypt-proxy version for architecture {{ dnscrypt_arch.archive }} "
+  ansible.builtin.set_fact:
     dnscrypt_latest_version: "{{ item['browser_download_url'].split('/')[7] }}"
 # another way to do this:
 #    dnscrypt_latest_version: "{{ dnscrypt_latest_version | regex_replace('^.*download\\/(.*)\\/.*$', '\\1') }}"
   with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
-  no_log: yes  # prevent huge green or yellow output
+  no_log: true  # prevent huge green or yellow output
   when:
-  - not dnscrypt_latest_all_arch.failed
-  - dnscrypt_arch.archive in item.name
-  - not item.name.endswith("minisig")
+    - not dnscrypt_latest_all_arch.failed
+    - dnscrypt_arch.archive in item.name
+    - not item.name.endswith("minisig")
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
-- name: "[install] Download dnscrypt-proxy version: {{ dnscrypt_latest_version }} (no_log: yes)"
-  unarchive:
-    remote_src: yes
+- name: "[install] Download dnscrypt-proxy version: {{ dnscrypt_latest_version }}"
+  ansible.builtin.unarchive:
+    remote_src: true
     src: "{{ item['browser_download_url'] }}"
     dest: /opt/dnscrypt-proxy
-  become: yes
-  no_log: yes  # prevent huge green or yellow output
+  become: true
+  no_log: true  # prevent huge green or yellow output
   with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
   when: dnscrypt_arch.archive in item.name and not item.name.endswith("minisig")
   notify:
-  - Restart dnscrypt-proxy.socket systemd unit
-  - Run 'dnscrypt-proxy -service restart'
+    - Restart dnscrypt-proxy.socket systemd unit
+    - Run 'dnscrypt-proxy -service restart'
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
-- name: "[install] Symlink binary /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy to {{ dnscrypt_bin }}"
-  file: src="/opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy" dest="{{ dnscrypt_bin }}" state=link
-  become: yes
+- name: "[install] Symlink binary {{ dnscrypt_bin }}"
+  ansible.builtin.file:
+    src: "/opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+    dest: "{{ dnscrypt_bin }}"
+    state: link
+  become: true
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
 - name: "[install] Check dnscrypt-proxy binary capabilities for running it as unprivileged user"
-  command: "setcap -v cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
-  become: yes
+  ansible.builtin.command:
+    cmd: "setcap -v cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+  become: true
   changed_when: false
   failed_when: false
   register: dnscrypt_bin_cap
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
 - name: "[install] Fix dnscrypt-proxy binary capabilities for running it as unprivileged user"
-  command: "setcap cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
-  become: yes
+  ansible.builtin.command:
+    cmd: "setcap cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+  become: true
   when: dnscrypt_bin_cap.rc != 0
+  changed_when: false
   tags:
-  - dnscrypt
-  - dnscrypt_install
+    - dnscrypt
+    - dnscrypt_install
 
-- name: "[install] Generate /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy.toml configuration file"
-  template: src=dnscrypt-proxy.toml.j2 dest="{{ dnscrypt_config }}"
-  become: yes
+- name: "[install] Generate dnscrypt-proxy.toml configuration file"
+  ansible.builtin.template:
+    src: dnscrypt-proxy.toml.j2
+    dest: "{{ dnscrypt_config }}"
+    mode: '0644'
+  become: true
   notify:
-  - Restart dnscrypt-proxy.socket systemd unit
-  - Run 'dnscrypt-proxy -service restart'
+    - Restart dnscrypt-proxy.socket systemd unit
+    - Run 'dnscrypt-proxy -service restart'
   tags:
-  - dnscrypt
-  - dnscrypt_install
-...
+    - dnscrypt
+    - dnscrypt_install

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,5 @@
 ---
-- name: "[install] Install dnscrypt-proxy"
+- name: "Install dnscrypt-proxy"
   tags:
     - dnscrypt
     - dnscrypt_install

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -59,6 +59,20 @@
   tags:
     - dnscrypt
     - dnscrypt_install
+- name: Debug dnscrypt_latest_version
+  ansible.builtin.debug:
+    var: dnscrypt_latest_version
+  tags:
+    - dnscrypt
+    - dnscrypt_install
+
+- name: Debug - is dnscrypt_latest_version equal or higher then 2.0.38?
+  ansible.builtin.debug:
+    msg: "dnscrypt_latest_version is equal or higher then 2.0.38"
+  when: dnscrypt_latest_version | version_compare('2.0.38', '>=')
+  tags:
+    - dnscrypt
+    - dnscrypt_install
 
 - name: "[install] Download dnscrypt-proxy version: {{ dnscrypt_latest_version }}"
   ansible.builtin.unarchive:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,115 +1,88 @@
 ---
-- name: "[install] Ensure that the required directories exist"
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    mode: '0755'
-  with_items:
-    - "{{ config_prefix | default('/') }}etc/dnscrypt-proxy/"
-    - /opt/dnscrypt-proxy/
+- name: "[install] Install dnscrypt-proxy"
   tags:
     - dnscrypt
     - dnscrypt_install
+  block:
+    - name: "[install] Ensure that the required directories exist"
+      ansible.builtin.file:
+      path: "{{ item }}"
+      state: directory
+      mode: '0755'
+      with_items:
+        - "{{ config_prefix | default('/') }}etc/dnscrypt-proxy/"
+        - /opt/dnscrypt-proxy/
 
-- name: "[install] Retrieve the latest dnscrypt-proxy versions for all architectures"
-  ansible.builtin.uri:
-    url: https://api.github.com/repos/jedisct1/dnscrypt-proxy/releases/latest
-  register: dnscrypt_latest_all_arch
-  ignore_errors: true
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Retrieve the latest dnscrypt-proxy versions for all architectures"
+      ansible.builtin.uri:
+      url: https://api.github.com/repos/jedisct1/dnscrypt-proxy/releases/latest
+      register: dnscrypt_latest_all_arch
+      ignore_errors: true
 
-- name: "[install] Set default dnscrypt-proxy assets only if failed retrieving the latest version"
-  ansible.builtin.set_fact:
-    dnscrypt_latest_all_arch:
-      failed: true
-      json:
-        assets:
-          - name: "dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
-            browser_download_url:
-              "https://github.com/jedisct1/dnscrypt-proxy/releases/download/\
-              {{ dnscrypt_default_version }}/\
-              dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
-  when: dnscrypt_latest_all_arch.failed
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Set default dnscrypt-proxy assets only if failed retrieving the latest version"
+      ansible.builtin.set_fact:
+      dnscrypt_latest_all_arch:
+        failed: true
+        json:
+          assets:
+            - name: "dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
+              browser_download_url:
+                "https://github.com/jedisct1/dnscrypt-proxy/releases/download/\
+                {{ dnscrypt_default_version }}/\
+                dnscrypt-proxy-{{ dnscrypt_arch.archive }}-{{ dnscrypt_default_version }}.tar.gz"
+      when: dnscrypt_latest_all_arch.failed
 
-- name: "[install] Fall back to default dnscrypt-proxy version: {{ dnscrypt_default_version }}"
-  ansible.builtin.set_fact:
-    dnscrypt_latest_version: "{{ dnscrypt_default_version }}"
-  when: dnscrypt_latest_all_arch.failed
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Fall back to default dnscrypt-proxy version: {{ dnscrypt_default_version }}"
+      ansible.builtin.set_fact:
+      dnscrypt_latest_version: "{{ dnscrypt_default_version }}"
+      when: dnscrypt_latest_all_arch.failed
 
-- name: "[install] Find the latest dnscrypt-proxy version for architecture {{ dnscrypt_arch.archive }} "
-  ansible.builtin.set_fact:
-    dnscrypt_latest_version: "{{ item['browser_download_url'].split('/')[7] }}"
-# another way to do this:
-#    dnscrypt_latest_version: "{{ dnscrypt_latest_version | regex_replace('^.*download\\/(.*)\\/.*$', '\\1') }}"
-  with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
-  no_log: true  # prevent huge green or yellow output
-  when:
-    - not dnscrypt_latest_all_arch.failed
-    - dnscrypt_arch.archive in item.name
-    - not item.name.endswith("minisig")
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Find the latest dnscrypt-proxy version for architecture {{ dnscrypt_arch.archive }} "
+      ansible.builtin.set_fact:
+      dnscrypt_latest_version: "{{ item['browser_download_url'].split('/')[7] }}"
+      with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
+      no_log: true  # prevent huge green or yellow output
+      when:
+        - not dnscrypt_latest_all_arch.failed
+        - dnscrypt_arch.archive in item.name
+        - not item.name.endswith("minisig")
 
-- name: "[install] Download dnscrypt-proxy version: {{ dnscrypt_latest_version }}"
-  ansible.builtin.unarchive:
-    remote_src: true
-    src: "{{ item['browser_download_url'] }}"
-    dest: /opt/dnscrypt-proxy
-  no_log: true  # prevent huge green or yellow output
-  with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
-  when: dnscrypt_arch.archive in item.name and not item.name.endswith("minisig")
-  notify:
-    - Restart dnscrypt-proxy.socket systemd unit
-    - Run 'dnscrypt-proxy -service restart'
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Download dnscrypt-proxy version: {{ dnscrypt_latest_version }}"
+      ansible.builtin.unarchive:
+      remote_src: true
+      src: "{{ item['browser_download_url'] }}"
+      dest: /opt/dnscrypt-proxy
+      no_log: true  # prevent huge green or yellow output
+      with_items: "{{ dnscrypt_latest_all_arch['json']['assets'] }}"
+      when: dnscrypt_arch.archive in item.name and not item.name.endswith("minisig")
+      notify:
+        - Restart dnscrypt-proxy.socket systemd unit
+        - Run 'dnscrypt-proxy -service restart'
 
-- name: "[install] Symlink binary {{ dnscrypt_bin }}"
-  ansible.builtin.file:
-    src: "/opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
-    dest: "{{ dnscrypt_bin }}"
-    state: link
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Symlink binary {{ dnscrypt_bin }}"
+      ansible.builtin.file:
+      src: "/opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+      dest: "{{ dnscrypt_bin }}"
+      state: link
 
-- name: "[install] Check dnscrypt-proxy binary capabilities for running it as unprivileged user"
-  ansible.builtin.command:
-    cmd: "setcap -v cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
-  changed_when: false
-  failed_when: false
-  register: dnscrypt_bin_cap
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Check dnscrypt-proxy binary capabilities for running it as unprivileged user"
+      ansible.builtin.command:
+      cmd: "setcap -v cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+      changed_when: false
+      failed_when: false
+      register: dnscrypt_bin_cap
 
-- name: "[install] Fix dnscrypt-proxy binary capabilities for running it as unprivileged user"
-  ansible.builtin.command:
-    cmd: "setcap cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
-  when: dnscrypt_bin_cap.rc != 0
-  changed_when: false
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Fix dnscrypt-proxy binary capabilities for running it as unprivileged user"
+      ansible.builtin.command:
+      cmd: "setcap cap_net_bind_service=+pe /opt/dnscrypt-proxy/{{ dnscrypt_arch.dir }}/dnscrypt-proxy"
+      when: dnscrypt_bin_cap.rc != 0
+      changed_when: false
 
-- name: "[install] Generate dnscrypt-proxy.toml configuration file"
-  ansible.builtin.template:
-    src: dnscrypt-proxy.toml.j2
-    dest: "{{ dnscrypt_config }}"
-    mode: '0644'
-  notify:
-    - Restart dnscrypt-proxy.socket systemd unit
-    - Run 'dnscrypt-proxy -service restart'
-  tags:
-    - dnscrypt
-    - dnscrypt_install
+    - name: "[install] Generate dnscrypt-proxy.toml configuration file"
+      ansible.builtin.template:
+      src: dnscrypt-proxy.toml.j2
+      dest: "{{ dnscrypt_config }}"
+      mode: '0644'
+      notify:
+        - Restart dnscrypt-proxy.socket systemd unit
+        - Run 'dnscrypt-proxy -service restart'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -59,20 +59,6 @@
   tags:
     - dnscrypt
     - dnscrypt_install
-- name: Debug dnscrypt_latest_version
-  ansible.builtin.debug:
-    var: dnscrypt_latest_version
-  tags:
-    - dnscrypt
-    - dnscrypt_install
-
-- name: Debug - is dnscrypt_latest_version equal or higher then 2.0.38?
-  ansible.builtin.debug:
-    msg: "dnscrypt_latest_version is equal or higher then 2.0.38"
-  when: dnscrypt_latest_version is version('2.0.38', '>=')
-  tags:
-    - dnscrypt
-    - dnscrypt_install
 
 - name: "[install] Download dnscrypt-proxy version: {{ dnscrypt_latest_version }}"
   ansible.builtin.unarchive:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -69,7 +69,7 @@
 - name: Debug - is dnscrypt_latest_version equal or higher then 2.0.38?
   ansible.builtin.debug:
     msg: "dnscrypt_latest_version is equal or higher then 2.0.38"
-  when: dnscrypt_latest_version | version_compare('2.0.38', '>=')
+  when: dnscrypt_latest_version is version('2.0.38', '>=')
   tags:
     - dnscrypt
     - dnscrypt_install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
   ansible.builtin.import_tasks: install.yml
   tags:
     - dnscrypt
+    - dnscrypt_install
 
 - name: '[main] Check if distribution uses systemd init'
   ansible.builtin.stat:
@@ -33,4 +34,6 @@
   ansible.builtin.meta: flush_handlers
   tags:
     - dnscrypt
+    - dnscrypt_install
+    - dnscrypt_systemd
     - dnscrypt_pihole

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,34 +2,36 @@
 # tasks file for ansible-dnscrypt
 
 - name: '[main] Import dnscrypt-proxy install-related tasks'
-  import_tasks: install.yml
+  ansible.builtin.import_tasks: install.yml
   tags:
-  - dnscrypt
+    - dnscrypt
 
 - name: '[main] Check if distribution uses systemd init'
-  stat: path=/bin/systemctl
+  ansible.builtin.stat:
+    path: /bin/systemctl
   register: dnscrypt_systemd
   tags:
-  - dnscrypt
-  - dnscrypt_systemd
+    - dnscrypt
+    - dnscrypt_systemd
 
 - name: '[main] Include systemd-related tasks, if distro is using systemd init'
-  include_tasks: systemd.yml
+  ansible.builtin.include_tasks: systemd.yml
   when: dnscrypt_systemd.stat.exists
   tags:
-  - dnscrypt
-  - dnscrypt_systemd
+    - dnscrypt
+    - dnscrypt_systemd
 
 # Modify PIHOLE
 - name: '[main] Include pihole-related tasks'
-  include_tasks: pihole.yml
+  ansible.builtin.include_tasks: pihole.yml
   when: dnscrypt_on_pihole
   tags:
-  - dnscrypt
-  - dnscrypt_pihole
+    - dnscrypt
+    - dnscrypt_pihole
 
-- meta: flush_handlers
+- name: '[main] Flush handlers'
+  ansible.builtin.meta: flush_handlers
   tags:
-  - dnscrypt
-  - dnscrypt_pihole
+    - dnscrypt
+    - dnscrypt_pihole
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,4 +34,3 @@
   tags:
     - dnscrypt
     - dnscrypt_pihole
-...

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -33,7 +33,7 @@
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
         backup: true
-      loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | slice(0, 3) }}"
+      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list) | length > 0 | ternary(unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | slice(0, 3), []) }}"
       loop_control:
         index_var: item_index
       notify: Restart pihole-FTL

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -21,18 +21,18 @@
 
     - name: '[pihole] Add PIHOLE_DNS_1 entry'
       ansible.builtin.lineinfile:
-      path: /etc/pihole/setupVars.conf
-      line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
-      state: present
-      backup: true
-      notify: Restart pihole-FTL
+        path: /etc/pihole/setupVars.conf
+        line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+        state: present
+        backup: true
+        notify: Restart pihole-FTL
 
     - name: '[pihole] Add remaining PIHOLE_DNS_ entries'
       ansible.builtin.lineinfile:
-      path: /etc/pihole/setupVars.conf
-      line: 'PIHOLE_DNS_{{ item.index + 2 }}={{ item.ip }}'
-      state: present
-      backup: true
+        path: /etc/pihole/setupVars.conf
+        line: 'PIHOLE_DNS_{{ item.index + 2 }}={{ item.ip }}'
+        state: present
+        backup: true
       loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | enumerate }}"
       when: item.index < 3
       notify: Restart pihole-FTL

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -1,7 +1,7 @@
 ---
 
 
-- name: '[pihole] Ensure dnscrypt server is set in one of the four PIHOLE_DNS entries in /etc/pihole/setupVars.conf'
+- name: 'Pi-hole related tasks'
   tags:
     - dnscrypt
     - dnscrypt_pihole

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -24,19 +24,15 @@
       become: true
       notify: Restart pihole-FTL
     
-    - name: Debug - pihole_dns_entries
-      ansible.builtin.debug:
-        var: pihole_dns_entries
-
     - name: '[pihole] Ensure dnscrypt server is set in one of the four PIHOLE_DNS entries'
       ansible.builtin.lineinfile:
         path: /etc/pihole/setupVars.conf
-        regexp: '^PIHOLE_DNS_{{ item.index }}='
-        line: 'PIHOLE_DNS_{{ item.index }}={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+        regexp: '^PIHOLE_DNS_{{ item }}='
+        line: 'PIHOLE_DNS_{{ item }}={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
         backup: yes
       loop: "{{ range(1, 5) | map('int') | list }}"
-      when: item.index > pihole_dns_entries.stdout_lines | length
+      when: item > pihole_dns_entries.stdout_lines | length
       become: true
       notify: Restart pihole-FTL
 

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -1,32 +1,34 @@
 ---
 # Modify PIHOLE
 - name: '[pihole] Generate /etc/dnsmasq.d/02-dnscrypt.conf'
-  template: src=02-dnscrypt.conf.j2 dest=/etc/dnsmasq.d/02-dnscrypt.conf
-  become: yes
+  ansible.builtin.template:
+    src: 02-dnscrypt.conf.j2
+    dest: /etc/dnsmasq.d/02-dnscrypt.conf
+    mode: '0644'
+  become: true
   notify: Restart pihole-FTL
   tags:
-  - dnscrypt
-  - dnscrypt_pihole
+    - dnscrypt
+    - dnscrypt_pihole
 
 - name: '[pihole] Modify /etc/pihole/setupVars.conf'
-  replace:
+  ansible.builtin.replace:
     path: /etc/pihole/setupVars.conf
     regexp: '^(PIHOLE_DNS_[0-9]=.*)'
     replace: '#\1'
-  become: yes
+  become: true
   notify: Restart pihole-FTL
   tags:
-  - dnscrypt
-  - dnscrypt_pihole
+    - dnscrypt
+    - dnscrypt_pihole
 
 - name: '[pihole] Modify /etc/dnsmasq.d/01-pihole.conf'
-  replace:
+  ansible.builtin.replace:
     path: /etc/dnsmasq.d/01-pihole.conf
     regexp: '^(server=.*)'
     replace: '#\1'
-  become: yes
+  become: true
   notify: Restart pihole-FTL
   tags:
-  - dnscrypt
-  - dnscrypt_pihole
-...
+    - dnscrypt
+    - dnscrypt_pihole

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -6,52 +6,43 @@
     - dnscrypt
     - dnscrypt_pihole
   block:
-    - name: '[pihole] Get current PIHOLE_DNS entries'
-      ansible.builtin.command: grep '^PIHOLE_DNS_' /etc/pihole/setupVars.conf
-      register: pihole_dns_entries
+    - name: '[pihole] Collect unique IP addresses from PIHOLE_DNS entries'
+      ansible.builtin.shell: "grep '^PIHOLE_DNS_' /etc/pihole/setupVars.conf | grep -oP '(?<=PIHOLE_DNS_\\d=)[^#]+' | sort -u"
+      register: unique_pihole_dns_ips
       ignore_errors: true
-      become: true
       changed_when: false
 
-    - name: '[pihole] Set dnscrypt server in PIHOLE_DNS_1 if no entries exist'
+    - name: '[pihole] Remove all PIHOLE_DNS_ lines from /etc/pihole/setupVars.conf, including commented lines'
       ansible.builtin.lineinfile:
         path: /etc/pihole/setupVars.conf
-        regexp: '^PIHOLE_DNS_1='
+        regexp: '^\s*#?\s*PIHOLE_DNS_'
+        state: absent
+        backup: yes
+
+    - name: '[pihole] Recreate PIHOLE_DNS_ entries'
+      block:
+      - name: '[pihole] Add PIHOLE_DNS_1 entry'
+        ansible.builtin.lineinfile:
+        path: /etc/pihole/setupVars.conf
         line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
         backup: yes
-      when: pihole_dns_entries.stdout_lines is not defined or pihole_dns_entries.stdout_lines | length == 0
-      become: true
-      notify: Restart pihole-FTL
-    
-    - name: '[pihole] Ensure dnscrypt server is set in one of the four PIHOLE_DNS entries'
-      ansible.builtin.lineinfile:
-        path: /etc/pihole/setupVars.conf
-        regexp: '^PIHOLE_DNS_{{ item }}='
-        line: 'PIHOLE_DNS_{{ item }}={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
-        state: present
-        backup: yes
-      loop: "{{ range(1, 5) | map('int') | list }}"
-      when: item > pihole_dns_entries.stdout_lines | length
-      become: true
-      notify: Restart pihole-FTL
+        notify: Restart pihole-FTL
 
-    - name: '[pihole] Replace the last PIHOLE_DNS entry if there are already four'
-      ansible.builtin.lineinfile:
+      - name: '[pihole] Add remaining PIHOLE_DNS_ entries'
+        ansible.builtin.lineinfile:
         path: /etc/pihole/setupVars.conf
-        regexp: '^PIHOLE_DNS_4='
-        line: 'PIHOLE_DNS_4={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+        line: 'PIHOLE_DNS_{{ item.index + 2 }}={{ item.ip }}'
         state: present
         backup: yes
-      when: pihole_dns_entries.stdout_lines | length >= 4
-      become: true
-      notify: Restart pihole-FTL
+        loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | enumerate }}"
+        when: item.index < 3
+        notify: Restart pihole-FTL
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'
       ansible.builtin.command: grep '^server=' /etc/dnsmasq.d/01-pihole.conf
       register: dnsmasq_server_entries
       ignore_errors: true
-      become: true
       changed_when: false
 
     - name: '[pihole] Backup /etc/dnsmasq.d/01-pihole.conf'
@@ -59,12 +50,10 @@
         src: /etc/dnsmasq.d/01-pihole.conf
         dest: /etc/dnsmasq.d/01-pihole.conf.bak
         backup: yes
-      become: true
 
     - name: '[pihole] Ensure there are no more than 3 server entries in /etc/dnsmasq.d/01-pihole.conf'
       ansible.builtin.command: "sed -i '/^server=/{{N;N;N;s/\\nserver=.*//;}}' /etc/dnsmasq.d/01-pihole.conf"
       when: dnsmasq_server_entries.stdout_lines | length > 3
-      become: true
       notify: Restart pihole-FTL
 
     - name: '[pihole] Add dnscrypt server if less than 4 entries exist'
@@ -73,5 +62,4 @@
         line: 'server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
       when: dnsmasq_server_entries.stdout_lines | length < 4
-      become: true
       notify: Restart pihole-FTL

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -33,7 +33,7 @@
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
         backup: true
-      loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | slice(0, 3) }}"
+      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list)[:3] }}"
       loop_control:
         index_var: item_index
       notify: Restart pihole-FTL

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -33,10 +33,11 @@
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
         backup: true
-      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list) | length > 0 | ternary(unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | slice(0, 3), []) }}"
+      loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | slice(0, 3) }}"
       loop_control:
         index_var: item_index
       notify: Restart pihole-FTL
+      when: unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list| length > 0
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'
       ansible.builtin.command: grep '^server=' /etc/dnsmasq.d/01-pihole.conf

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -35,7 +35,7 @@
         backup: true
       loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list }}"
       vars:
-        item_index: "{{ ansible.utils.index_of(unique_pihole_dns_ips.stdout_lines, item) }}"
+        item_index: "{{ index_of(unique_pihole_dns_ips.stdout_lines, item) }}"
       when: item_index < 3
       notify: Restart pihole-FTL
 

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -23,6 +23,10 @@
       when: pihole_dns_entries.stdout_lines is not defined or pihole_dns_entries.stdout_lines | length == 0
       become: true
       notify: Restart pihole-FTL
+    
+    - name: Debug - pihole_dns_entries
+      ansible.builtin.debug:
+        var: pihole_dns_entries
 
     - name: '[pihole] Ensure dnscrypt server is set in one of the four PIHOLE_DNS entries'
       ansible.builtin.lineinfile:

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -33,10 +33,9 @@
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
         backup: true
-      loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list }}"
-      vars:
-        item_index: "{{ index_of(unique_pihole_dns_ips.stdout_lines, item) }}"
-      when: item_index < 3
+      loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | slice(0, 3) }}"
+      loop_control:
+        index_var: item_index
       notify: Restart pihole-FTL
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -17,14 +17,13 @@
         path: /etc/pihole/setupVars.conf
         regexp: '^\s*#?\s*PIHOLE_DNS_'
         state: absent
-        backup: yes
+        backup: true
 
     - name: '[pihole] Add PIHOLE_DNS_1 entry'
       ansible.builtin.lineinfile:
         path: /etc/pihole/setupVars.conf
         line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
-        backup: true
       notify: Restart pihole-FTL
 
     - name: '[pihole] Add remaining PIHOLE_DNS_ entries'
@@ -32,7 +31,6 @@
         path: /etc/pihole/setupVars.conf
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
-        backup: true
       loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port | string) | list) }}"
       loop_control:
         index_var: item_index
@@ -42,7 +40,7 @@
         - item_index < 3
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'
-      ansible.builtin.command: grep '^server=' /etc/dnsmasq.d/01-pihole.conf
+      ansible.builtin.shell: "grep '^server=' /etc/dnsmasq.d/01-pihole.conf | grep -oP '(?<=server=).*' | sort -u"
       register: dnsmasq_server_entries
       ignore_errors: true
       changed_when: false
@@ -59,7 +57,6 @@
         path: /etc/dnsmasq.d/01-pihole.conf
         line: 'server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
-        backup: true
       notify: Restart pihole-FTL
 
     - name: '[pihole] Add remaining server entries'
@@ -67,7 +64,6 @@
         path: /etc/dnsmasq.d/01-pihole.conf
         line: 'server={{ item }}'
         state: present
-        backup: true
       loop: "{{ (dnsmasq_server_entries.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port | string) | list) }}"
       loop_control:
         index_var: item_index

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -33,11 +33,13 @@
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
         backup: true
-      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list) }}"
+      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port) | list) }}"
       loop_control:
         index_var: item_index
       notify: Restart pihole-FTL
-      when: unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list| length > 0
+      when: 
+        - unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port) | list | length > 0
+        - index_var < 3
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'
       ansible.builtin.command: grep '^server=' /etc/dnsmasq.d/01-pihole.conf

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -34,7 +34,9 @@
         state: present
         backup: true
       loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list }}"
-      when: "{{ unique_pihole_dns_ips.stdout_lines.index(item) < 3 }}"
+      vars:
+        item_index: "{{ ansible.utils.index_of(unique_pihole_dns_ips.stdout_lines, item) }}"
+      when: item_index < 3
       notify: Restart pihole-FTL
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -19,14 +19,14 @@
         state: absent
         backup: true
 
-    - name: '[pihole] Add PIHOLE_DNS_1 entry'
+    - name: '[pihole] Add PIHOLE_DNS_1 entry to /etc/pihole/setupVars.conf'
       ansible.builtin.lineinfile:
         path: /etc/pihole/setupVars.conf
         line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
       notify: Restart pihole-FTL
 
-    - name: '[pihole] Add remaining PIHOLE_DNS_ entries'
+    - name: '[pihole] Add remaining PIHOLE_DNS_ entries to /etc/pihole/setupVars.conf'
       ansible.builtin.lineinfile:
         path: /etc/pihole/setupVars.conf
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
@@ -45,21 +45,21 @@
       ignore_errors: true
       changed_when: false
 
-    - name: '[pihole] Remove all server= lines from /etc/dnsmasq.d/01-pihole.conf, including commented lines'
+    - name: '[pihole] Remove all server lines from /etc/dnsmasq.d/01-pihole.conf, including commented lines'
       ansible.builtin.lineinfile:
         path: /etc/dnsmasq.d/01-pihole.conf
         regexp: '^\s*#?\s*server='
         state: absent
         backup: true
 
-    - name: '[pihole] Add server entry'
+    - name: '[pihole] Add first server entry to /etc/dnsmasq.d/01-pihole.conf'
       ansible.builtin.lineinfile:
         path: /etc/dnsmasq.d/01-pihole.conf
         line: 'server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
       notify: Restart pihole-FTL
 
-    - name: '[pihole] Add remaining server entries'
+    - name: '[pihole] Add remaining server entries to /etc/dnsmasq.d/01-pihole.conf'
       ansible.builtin.lineinfile:
         path: /etc/dnsmasq.d/01-pihole.conf
         line: 'server={{ item }}'

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -1,49 +1,77 @@
 ---
-- name: '[pihole] Remove duplicate `PIHOLE_DNS_[0-9]` entries in /etc/pihole/setupVars.conf'
-  ansible.builtin.lineinfile:
-    path: /etc/pihole/setupVars.conf
-    regexp: '^PIHOLE_DNS_[0-9]='
-    state: absent
-    backup: true
-  become: true
-  notify: Restart pihole-FTL
-  tags:
-    - dnscrypt
-    - dnscrypt_pihole
 
-- name: '[pihole] Ensure dnscrypt server is set in /etc/pihole/setupVars.conf'
-  ansible.builtin.lineinfile:
-    path: /etc/pihole/setupVars.conf
-    regexp: '^PIHOLE_DNS_[0-9]='
-    line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
-    state: present
-  become: true
-  notify: Restart pihole-FTL
-  tags:
-    - dnscrypt
-    - dnscrypt_pihole
 
-- name: '[pihole] Remove duplicate `server=` entries in /etc/dnsmasq.d/01-pihole.conf'
-  ansible.builtin.lineinfile:
-    path: /etc/dnsmasq.d/01-pihole.conf
-    regexp: '^server='
-    line: ''
-    state: absent
-    backup: true
-  become: true
-  notify: Restart pihole-FTL
+- name: '[pihole] Ensure dnscrypt server is set in one of the four PIHOLE_DNS entries in /etc/pihole/setupVars.conf'
   tags:
     - dnscrypt
     - dnscrypt_pihole
+  block:
+    - name: '[pihole] Get current PIHOLE_DNS entries'
+      ansible.builtin.command: grep '^PIHOLE_DNS_' /etc/pihole/setupVars.conf
+      register: pihole_dns_entries
+      ignore_errors: true
+      become: true
+      changed_when: false
 
-- name: '[pihole] Ensure unique dnscrypt server is configured in /etc/dnsmasq.d/01-pihole.conf'
-  ansible.builtin.lineinfile:
-    path: /etc/dnsmasq.d/01-pihole.conf
-    regexp: '^server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
-    line: 'server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
-    state: present
-  become: true
-  notify: Restart pihole-FTL
-  tags:
-    - dnscrypt
-    - dnscrypt_pihole
+    - name: '[pihole] Set dnscrypt server in PIHOLE_DNS_1 if no entries exist'
+      ansible.builtin.lineinfile:
+        path: /etc/pihole/setupVars.conf
+        regexp: '^PIHOLE_DNS_1='
+        line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+        state: present
+        backup: yes
+      when: pihole_dns_entries.stdout_lines is not defined or pihole_dns_entries.stdout_lines | length == 0
+      become: true
+      notify: Restart pihole-FTL
+
+    - name: '[pihole] Ensure dnscrypt server is set in one of the four PIHOLE_DNS entries'
+      ansible.builtin.lineinfile:
+        path: /etc/pihole/setupVars.conf
+        regexp: '^PIHOLE_DNS_{{ item.index }}='
+        line: 'PIHOLE_DNS_{{ item.index }}={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+        state: present
+        backup: yes
+      loop: "{{ range(1, 5) | map('int') | list }}"
+      when: item.index > pihole_dns_entries.stdout_lines | length
+      become: true
+      notify: Restart pihole-FTL
+
+    - name: '[pihole] Replace the last PIHOLE_DNS entry if there are already four'
+      ansible.builtin.lineinfile:
+        path: /etc/pihole/setupVars.conf
+        regexp: '^PIHOLE_DNS_4='
+        line: 'PIHOLE_DNS_4={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+        state: present
+        backup: yes
+      when: pihole_dns_entries.stdout_lines | length >= 4
+      become: true
+      notify: Restart pihole-FTL
+
+    - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'
+      ansible.builtin.command: grep '^server=' /etc/dnsmasq.d/01-pihole.conf
+      register: dnsmasq_server_entries
+      ignore_errors: true
+      become: true
+      changed_when: false
+
+    - name: '[pihole] Backup /etc/dnsmasq.d/01-pihole.conf'
+      ansible.builtin.copy:
+        src: /etc/dnsmasq.d/01-pihole.conf
+        dest: /etc/dnsmasq.d/01-pihole.conf.bak
+        backup: yes
+      become: true
+
+    - name: '[pihole] Ensure there are no more than 3 server entries in /etc/dnsmasq.d/01-pihole.conf'
+      ansible.builtin.command: "sed -i '/^server=/{{N;N;N;s/\\nserver=.*//;}}' /etc/dnsmasq.d/01-pihole.conf"
+      when: dnsmasq_server_entries.stdout_lines | length > 3
+      become: true
+      notify: Restart pihole-FTL
+
+    - name: '[pihole] Add dnscrypt server if less than 4 entries exist'
+      ansible.builtin.lineinfile:
+        path: /etc/dnsmasq.d/01-pihole.conf
+        line: 'server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+        state: present
+      when: dnsmasq_server_entries.stdout_lines | length < 4
+      become: true
+      notify: Restart pihole-FTL

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -25,7 +25,7 @@
         line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
         backup: true
-        notify: Restart pihole-FTL
+      notify: Restart pihole-FTL
 
     - name: '[pihole] Add remaining PIHOLE_DNS_ entries'
       ansible.builtin.lineinfile:

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -6,7 +6,7 @@
     - dnscrypt
     - dnscrypt_pihole
   block:
-    - name: '[pihole] Collect unique IP addresses from PIHOLE_DNS entries'
+    - name: '[pihole] Collect unique IP addresses and ports from PIHOLE_DNS entries'
       ansible.builtin.shell: "grep '^PIHOLE_DNS_' /etc/pihole/setupVars.conf | grep -oP '(?<=PIHOLE_DNS_\\d=)[^#]+' | sort -u"
       register: unique_pihole_dns_ips
       ignore_errors: true
@@ -19,25 +19,23 @@
         state: absent
         backup: yes
 
-    - name: '[pihole] Recreate PIHOLE_DNS_ entries'
-      block:
-      - name: '[pihole] Add PIHOLE_DNS_1 entry'
-        ansible.builtin.lineinfile:
-        path: /etc/pihole/setupVars.conf
-        line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
-        state: present
-        backup: yes
-        notify: Restart pihole-FTL
+    - name: '[pihole] Add PIHOLE_DNS_1 entry'
+      ansible.builtin.lineinfile:
+      path: /etc/pihole/setupVars.conf
+      line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+      state: present
+      backup: true
+      notify: Restart pihole-FTL
 
-      - name: '[pihole] Add remaining PIHOLE_DNS_ entries'
-        ansible.builtin.lineinfile:
-        path: /etc/pihole/setupVars.conf
-        line: 'PIHOLE_DNS_{{ item.index + 2 }}={{ item.ip }}'
-        state: present
-        backup: yes
-        loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | enumerate }}"
-        when: item.index < 3
-        notify: Restart pihole-FTL
+    - name: '[pihole] Add remaining PIHOLE_DNS_ entries'
+      ansible.builtin.lineinfile:
+      path: /etc/pihole/setupVars.conf
+      line: 'PIHOLE_DNS_{{ item.index + 2 }}={{ item.ip }}'
+      state: present
+      backup: true
+      loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | enumerate }}"
+      when: item.index < 3
+      notify: Restart pihole-FTL
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'
       ansible.builtin.command: grep '^server=' /etc/dnsmasq.d/01-pihole.conf

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -7,7 +7,7 @@
     - dnscrypt_pihole
   block:
     - name: '[pihole] Collect unique IP addresses and ports from PIHOLE_DNS entries'
-      ansible.builtin.shell: "grep '^PIHOLE_DNS_' /etc/pihole/setupVars.conf | grep -oP '(?<=PIHOLE_DNS_\\d=)[^#]+' | sort -u"
+      ansible.builtin.shell: "grep '^PIHOLE_DNS_' /etc/pihole/setupVars.conf | grep -oP '(?<=PIHOLE_DNS_\\d=).*' | sort -u"
       register: unique_pihole_dns_ips
       ignore_errors: true
       changed_when: false

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -39,7 +39,7 @@
       notify: Restart pihole-FTL
       when: 
         - unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port) | list | length > 0
-        - index_var < 3
+        - item_index < 3
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'
       ansible.builtin.command: grep '^server=' /etc/dnsmasq.d/01-pihole.conf

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -30,11 +30,13 @@
     - name: '[pihole] Add remaining PIHOLE_DNS_ entries'
       ansible.builtin.lineinfile:
         path: /etc/pihole/setupVars.conf
-        line: 'PIHOLE_DNS_{{ item.index + 2 }}={{ item.ip }}'
+        line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
         backup: true
-      loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list | enumerate }}"
-      when: item.index < 3
+      loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list }}"
+      vars:
+        item_index: "{{ ansible.utils.index_of(unique_pihole_dns_ips.stdout_lines, item) }}"
+      when: item_index < 3
       notify: Restart pihole-FTL
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -34,9 +34,7 @@
         state: present
         backup: true
       loop: "{{ unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list }}"
-      vars:
-        item_index: "{{ ansible.utils.index_of(unique_pihole_dns_ips.stdout_lines, item) }}"
-      when: item_index < 3
+      when: "{{ unique_pihole_dns_ips.stdout_lines.index(item) < 3 }}"
       notify: Restart pihole-FTL
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -33,7 +33,7 @@
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
         backup: true
-      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list)[:3] }}"
+      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address) | list) }}"
       loop_control:
         index_var: item_index
       notify: Restart pihole-FTL

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -33,12 +33,12 @@
         line: 'PIHOLE_DNS_{{ item_index + 2 }}={{ item }}'
         state: present
         backup: true
-      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port) | list) }}"
+      loop: "{{ (unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port | string) | list) }}"
       loop_control:
         index_var: item_index
       notify: Restart pihole-FTL
       when: 
-        - unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port) | list | length > 0
+        - unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port | string) | list | length > 0
         - item_index < 3
 
     - name: '[pihole] Get current server entries in /etc/dnsmasq.d/01-pihole.conf'

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -1,10 +1,10 @@
 ---
-# Modify PIHOLE
-- name: '[pihole] Comment all `PIHOLE_DNS_[0-9]` entries in /etc/pihole/setupVars.conf'
-  ansible.builtin.replace:
+- name: '[pihole] Remove duplicate `PIHOLE_DNS_[0-9]` entries in /etc/pihole/setupVars.conf'
+  ansible.builtin.lineinfile:
     path: /etc/pihole/setupVars.conf
-    regexp: '^(PIHOLE_DNS_[0-9]=.*)'
-    replace: '#\1'
+    regexp: '^PIHOLE_DNS_[0-9]='
+    state: absent
+    backup: true
   become: true
   notify: Restart pihole-FTL
   tags:
@@ -23,18 +23,20 @@
     - dnscrypt
     - dnscrypt_pihole
 
-- name: '[pihole] comment all `server=` entries /etc/dnsmasq.d/01-pihole.conf'
-  ansible.builtin.replace:
+- name: '[pihole] Remove duplicate `server=` entries in /etc/dnsmasq.d/01-pihole.conf'
+  ansible.builtin.lineinfile:
     path: /etc/dnsmasq.d/01-pihole.conf
-    regexp: '^(server=.*)'
-    replace: '#\1'
+    regexp: '^server='
+    line: ''
+    state: absent
+    backup: true
   become: true
   notify: Restart pihole-FTL
   tags:
     - dnscrypt
     - dnscrypt_pihole
 
-- name: '[pihole] Ensure dnscrypt server is configured in /etc/dnsmasq.d/01-pihole.conf'
+- name: '[pihole] Ensure unique dnscrypt server is configured in /etc/dnsmasq.d/01-pihole.conf'
   ansible.builtin.lineinfile:
     path: /etc/dnsmasq.d/01-pihole.conf
     regexp: '^server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -37,7 +37,7 @@
       loop_control:
         index_var: item_index
       notify: Restart pihole-FTL
-      when: 
+      when:
         - unique_pihole_dns_ips.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port | string) | list | length > 0
         - item_index < 3
 
@@ -47,21 +47,31 @@
       ignore_errors: true
       changed_when: false
 
-    - name: '[pihole] Backup /etc/dnsmasq.d/01-pihole.conf'
-      ansible.builtin.copy:
-        src: /etc/dnsmasq.d/01-pihole.conf
-        dest: /etc/dnsmasq.d/01-pihole.conf.bak
-        backup: yes
+    - name: '[pihole] Remove all server= lines from /etc/dnsmasq.d/01-pihole.conf, including commented lines'
+      ansible.builtin.lineinfile:
+        path: /etc/dnsmasq.d/01-pihole.conf
+        regexp: '^\s*#?\s*server='
+        state: absent
+        backup: true
 
-    - name: '[pihole] Ensure there are no more than 3 server entries in /etc/dnsmasq.d/01-pihole.conf'
-      ansible.builtin.command: "sed -i '/^server=/{{N;N;N;s/\\nserver=.*//;}}' /etc/dnsmasq.d/01-pihole.conf"
-      when: dnsmasq_server_entries.stdout_lines | length > 3
-      notify: Restart pihole-FTL
-
-    - name: '[pihole] Add dnscrypt server if less than 4 entries exist'
+    - name: '[pihole] Add server entry'
       ansible.builtin.lineinfile:
         path: /etc/dnsmasq.d/01-pihole.conf
         line: 'server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
         state: present
-      when: dnsmasq_server_entries.stdout_lines | length < 4
+        backup: true
       notify: Restart pihole-FTL
+
+    - name: '[pihole] Add remaining server entries'
+      ansible.builtin.lineinfile:
+        path: /etc/dnsmasq.d/01-pihole.conf
+        line: 'server={{ item }}'
+        state: present
+        backup: true
+      loop: "{{ (dnsmasq_server_entries.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port | string) | list) }}"
+      loop_control:
+        index_var: item_index
+      notify: Restart pihole-FTL
+      when:
+        - dnsmasq_server_entries.stdout_lines | reject('equalto', dnscrypt_ipv4_address + '#' + dnscrypt_port | string) | list | length > 0
+        - item_index < 3

--- a/tasks/pihole.yml
+++ b/tasks/pihole.yml
@@ -1,17 +1,6 @@
 ---
 # Modify PIHOLE
-- name: '[pihole] Generate /etc/dnsmasq.d/02-dnscrypt.conf'
-  ansible.builtin.template:
-    src: 02-dnscrypt.conf.j2
-    dest: /etc/dnsmasq.d/02-dnscrypt.conf
-    mode: '0644'
-  become: true
-  notify: Restart pihole-FTL
-  tags:
-    - dnscrypt
-    - dnscrypt_pihole
-
-- name: '[pihole] Modify /etc/pihole/setupVars.conf'
+- name: '[pihole] Comment all `PIHOLE_DNS_[0-9]` entries in /etc/pihole/setupVars.conf'
   ansible.builtin.replace:
     path: /etc/pihole/setupVars.conf
     regexp: '^(PIHOLE_DNS_[0-9]=.*)'
@@ -22,11 +11,35 @@
     - dnscrypt
     - dnscrypt_pihole
 
-- name: '[pihole] Modify /etc/dnsmasq.d/01-pihole.conf'
+- name: '[pihole] Ensure dnscrypt server is set in /etc/pihole/setupVars.conf'
+  ansible.builtin.lineinfile:
+    path: /etc/pihole/setupVars.conf
+    regexp: '^PIHOLE_DNS_[0-9]='
+    line: 'PIHOLE_DNS_1={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+    state: present
+  become: true
+  notify: Restart pihole-FTL
+  tags:
+    - dnscrypt
+    - dnscrypt_pihole
+
+- name: '[pihole] comment all `server=` entries /etc/dnsmasq.d/01-pihole.conf'
   ansible.builtin.replace:
     path: /etc/dnsmasq.d/01-pihole.conf
     regexp: '^(server=.*)'
     replace: '#\1'
+  become: true
+  notify: Restart pihole-FTL
+  tags:
+    - dnscrypt
+    - dnscrypt_pihole
+
+- name: '[pihole] Ensure dnscrypt server is configured in /etc/dnsmasq.d/01-pihole.conf'
+  ansible.builtin.lineinfile:
+    path: /etc/dnsmasq.d/01-pihole.conf
+    regexp: '^server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+    line: 'server={{ dnscrypt_ipv4_address }}#{{ dnscrypt_port }}'
+    state: present
   become: true
   notify: Restart pihole-FTL
   tags:

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,28 +1,27 @@
 ---
 # Systemd
 - name: '[systemd] Generate systemd dnscrypt-proxy.socket unit'
-  template:
+  ansible.builtin.template:
     src: systemd/dnscrypt-proxy.socket.j2
     dest: /lib/systemd/system/dnscrypt-proxy.socket
     owner: root
     group: root
-    mode: 0644
-  become: yes
+    mode: '0644'
+  become: true
   notify: Restart dnscrypt-proxy.socket systemd unit
   tags:
-  - dnscrypt
-  - dnscrypt_systemd
+    - dnscrypt
+    - dnscrypt_systemd
 
 - name: '[systemd] Generate systemd dnscrypt-proxy.service unit'
-  template:
+  ansible.builtin.template:
     src: systemd/dnscrypt-proxy.service.j2
     dest: /lib/systemd/system/dnscrypt-proxy.service
     owner: root
     group: root
-    mode: 0644
-  become: yes
+    mode: '0644'
+  become: true
   notify: Restart dnscrypt-proxy.socket systemd unit
   tags:
-  - dnscrypt
-  - dnscrypt_systemd
-...
+    - dnscrypt
+    - dnscrypt_systemd

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,25 +1,24 @@
 ---
-# Systemd
-- name: '[systemd] Generate systemd dnscrypt-proxy.socket unit'
-  ansible.builtin.template:
-    src: systemd/dnscrypt-proxy.socket.j2
-    dest: /lib/systemd/system/dnscrypt-proxy.socket
-    owner: root
-    group: root
-    mode: '0644'
-  notify: Restart dnscrypt-proxy.socket systemd unit
+- name: 'Systemd-related tasks'
   tags:
     - dnscrypt
     - dnscrypt_systemd
+  block:
+    - name: '[systemd] Generate systemd dnscrypt-proxy.socket unit'
+      ansible.builtin.template:
+        src: systemd/dnscrypt-proxy.socket.j2
+        dest: /lib/systemd/system/dnscrypt-proxy.socket
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart dnscrypt-proxy.socket systemd unit
 
-- name: '[systemd] Generate systemd dnscrypt-proxy.service unit'
-  ansible.builtin.template:
-    src: systemd/dnscrypt-proxy.service.j2
-    dest: /lib/systemd/system/dnscrypt-proxy.service
-    owner: root
-    group: root
-    mode: '0644'
-  notify: Restart dnscrypt-proxy.socket systemd unit
-  tags:
-    - dnscrypt
-    - dnscrypt_systemd
+    - name: '[systemd] Generate systemd dnscrypt-proxy.service unit'
+      ansible.builtin.template:
+        src: systemd/dnscrypt-proxy.service.j2
+        dest: /lib/systemd/system/dnscrypt-proxy.service
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart dnscrypt-proxy.socket systemd unit
+

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -7,7 +7,6 @@
     owner: root
     group: root
     mode: '0644'
-  become: true
   notify: Restart dnscrypt-proxy.socket systemd unit
   tags:
     - dnscrypt
@@ -20,7 +19,6 @@
     owner: root
     group: root
     mode: '0644'
-  become: true
   notify: Restart dnscrypt-proxy.socket systemd unit
   tags:
     - dnscrypt

--- a/templates/dnscrypt-proxy.toml.j2
+++ b/templates/dnscrypt-proxy.toml.j2
@@ -73,13 +73,14 @@ force_tcp = {{ dnscrypt_force_tcp }}
 
 
 ## How long a DNS query will wait for a response, in milliseconds
-timeout = 2500
+timeout = {{ dnscrypt_timeout }}
 
 ## Keepalive for HTTP (HTTPS, HTTP/2) queries, in seconds
 keepalive = 30
 
 ## Load-balancing strategy: 'p2' (default), 'ph', 'fastest' or 'random'
-# lb_strategy = 'p2'
+lb_strategy = {{ dnscrypt_lb_strategy }}
+lb_estimator = {{ dnscrypt_lb_estimator }}
 
 ## Log level (0-6, default: 2 - 0 is very verbose, 6 only contains fatal errors)
 # log_level = 2
@@ -92,7 +93,6 @@ use_syslog = true
 
 ## Delay, in minutes, after which certificates are reloaded
 cert_refresh_delay = 240
-
 
 ## DNSCrypt: Create a new, unique key for every single DNS query
 ## This may improve privacy but can also have a significant impact on CPU usage
@@ -131,11 +131,13 @@ cert_refresh_delay = 240
 ## A resolver supporting DNSSEC is recommended. This may become mandatory.
 ##
 ## People in China may need to use 114.114.114.114:53 here.
-fallback_resolver = '{{ dnscrypt_fallback_resolver }}'
+
+bootstrap_resolvers = ['{{ dnscrypt_bootstrap_resolvers|join('\', \'')}}']
+# fallback_resolver = '{{ dnscrypt_fallback_resolver }}'
 
 ## Never try to use the system DNS settings; unconditionally use the
 ## fallback resolver.
-ignore_system_dns = false
+ignore_system_dns = {{ dnscrypt_ignore_system_dns }} 
 
 
 ## Maximum time (in seconds) to wait for network connectivity before
@@ -143,8 +145,8 @@ ignore_system_dns = false
 ## Useful if the proxy is automatically started at boot, and network
 ## connectivity is not guaranteed to be immediately available.
 ## Use 0 to disable.
-netprobe_timeout = 30
-
+netprobe_timeout = {{ dnscrypt_netprobe_timeout }}
+netprobe_address = '{{ dnscrypt_netprobe_address }}'
 
 ## Offline mode - Do not use any remote encrypted servers.
 ## The proxy will remain fully functional to respond to queries that
@@ -194,10 +196,10 @@ block_ipv6 = false
 cache = true
 
 ## Cache size
-cache_size = 512
+cache_size = {{ dnscrypt_cache_size }}
 
 ## Minimum TTL for cached entries
-cache_min_ttl = 600
+cache_min_ttl = {{ dnscrypt_cache_min_ttl }}
 
 ## Maximum TTL for cached entries
 cache_max_ttl = 86400
@@ -338,11 +340,11 @@ cache_neg_max_ttl = 600
 [sources]
   ## An example of a remote source
   [sources.'public-resolvers']
-  urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
-  cache_file = 'public-resolvers.md'
-  minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
-  refresh_delay = 72
-  prefix = ''
+    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
+    cache_file = 'public-resolvers.md'
+    minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+    refresh_delay = 72
+    prefix = ''
 
   ## Another example source, with resolvers censoring some websites not appropriate for children
   ## This is a subset of the `public-resolvers` list, so enabling both is useless
@@ -350,6 +352,33 @@ cache_neg_max_ttl = 600
   #  urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/parental-control.md', 'https://download.dnscrypt.info/resolvers-list/v2/parental-control.md']
   #  cache_file = 'parental-control.md'
   #  minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+
+  [sources.'relays']
+    urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/relays.md', 'https://download.dnscrypt.info/resolvers-list/v3/relays.md', 'https://ipv6.download.dnscrypt.info/resolvers-list/v3/relays.md', 'https://download.dnscrypt.net/resolvers-list/v3/relays.md']
+    cache_file = 'relays.md'
+    minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+    refresh_delay = 72
+    prefix = ''
+
+  [sources.dnscry-pt-resolvers]
+    urls = ["https://www.dnscry.pt/resolvers.md"]
+    minisign_key = "RWQM31Nwkqh01x88SvrBL8djp1NH56Rb4mKLHz16K7qsXgEomnDv6ziQ"
+    cache_file = "dnscry.pt-resolvers.md"
+    refresh_delay = 72
+    prefix = "dnscry.pt-"
+
+[broken_implementations]
+
+fragments_blocked = ['cisco', 'cisco-ipv6', 'cisco-familyshield', 'cisco-familyshield-ipv6', 'cleanbrowsing-adult', 'cleanbrowsing-adult-ipv6', 'cleanbrowsing-family', 'cleanbrowsing-family-ipv6', 'cleanbrowsing-security', 'cleanbrowsing-security-ipv6']
+
+[doh_client_x509_auth]
+
+[anonymized_dns]
+
+routes = [
+   { server_name=*, via=['anon-scaleway-ams','anon-sth-se','anon-v.dnscrypt.uk-ipv4,dnscry.pt-anon-madrid-ipv4','dnscry.pt-anon-munich-ipv4'] }
+   { server_name=*, via=['{{ dnscrypt_anonymizer_server_names|join('\', \'')}}'] }
+ ]
 
 ## Optional, local, static list of additional servers
 ## Mostly useful for testing your own servers.

--- a/templates/dnscrypt-proxy.toml.j2
+++ b/templates/dnscrypt-proxy.toml.j2
@@ -132,8 +132,11 @@ cert_refresh_delay = 240
 ##
 ## People in China may need to use 114.114.114.114:53 here.
 
+{% if dnscrypt_latest_version is version('2.0.38', '>=') %}
 bootstrap_resolvers = ['{{ dnscrypt_bootstrap_resolvers|join('\', \'')}}']
+{% else %}
 fallback_resolver = '{{ dnscrypt_fallback_resolver }}'
+{% endif %}
 
 ## Never try to use the system DNS settings; unconditionally use the
 ## fallback resolver.

--- a/templates/dnscrypt-proxy.toml.j2
+++ b/templates/dnscrypt-proxy.toml.j2
@@ -10,10 +10,20 @@ server_names = ['{{ dnscrypt_server_names|join('\', \'')}}']
 
 ## List of local addresses and ports to listen to. Can be IPv4 and/or IPv6.
 ## Note: When using systemd socket activation, choose an empty set (i.e. [] ).
+## List of local addresses and ports to listen to. Can be IPv4 and/or IPv6.
+## Example with both IPv4 and IPv6:
+## listen_addresses = ['[::1]:53']
+##
+## To listen to all IPv4 addresses, use `listen_addresses = ['0.0.0.0:53']`
+## To listen to all IPv4+IPv6 addresses, use `listen_addresses = ['[::]:53']`
 {% if dnscrypt_sysd_socket_only %}
 listen_addresses = []
 {% else %}
-listen_addresses = ['{{ dnscrypt_ipv4_address }}:{{ dnscrypt_port }}', '[::1]:{{ dnscrypt_port }}']
+{% if dnscrypt_ipv4_address == '127.0.0.1' %}
+listen_addresses = ['[::1]:{{ dnscrypt_port }}']
+{% else %}
+listen_addresses = ['{{ dnscrypt_ipv4_address }}:{{ dnscrypt_port }}', '[::]:{{ dnscrypt_port }}']
+{% endif %}
 {% endif %}
 
 ## Maximum number of simultaneous client connections to accept
@@ -377,10 +387,29 @@ fragments_blocked = ['cisco', 'cisco-ipv6', 'cisco-familyshield', 'cisco-familys
 [doh_client_x509_auth]
 
 [anonymized_dns]
+## !!! THESE ARE JUST EXAMPLES !!!
+##
+## Review the list of available relays from the "relays.md" file, and, for each
+## server you want to use, define the relays you want connections to go through.
+##
+## Carefully choose relays and servers so that they are run by different entities.
+##
+## "server_name" can also be set to "*" to define a default route, for all servers:
+## { server_name='*', via=['anon-example-1', 'anon-example-2'] }
+##
+## If a route is ["*"], the proxy automatically picks a relay on a distinct network.
+## { server_name='*', via=['*'] } is also an option, but is likely to be suboptimal.
+##
+## Manual selection is always recommended over automatic selection, so that you can
+## select (relay,server) pairs that work well and fit your own criteria (close by or
+## in different countries, operated by different entities, on distinct ISPs...)
 
+# routes = [
+#    { server_name='example-server-1', via=['anon-example-1', 'anon-example-2'] },
+#    { server_name='example-server-2', via=['sdns://gRIxMzcuNzQuMjIzLjIzNDo0NDM'] }
+# ]
 routes = [
-   { server_name=*, via=['anon-scaleway-ams','anon-sth-se','anon-v.dnscrypt.uk-ipv4,dnscry.pt-anon-madrid-ipv4','dnscry.pt-anon-munich-ipv4'] }
-   { server_name=*, via=['{{ dnscrypt_anonymizer_server_names|join('\', \'')}}'] }
+   { server_name='*', via=['{{ dnscrypt_anonymizer_server_names|join('\', \'')}}'] }
  ]
 
 ## Optional, local, static list of additional servers

--- a/templates/dnscrypt-proxy.toml.j2
+++ b/templates/dnscrypt-proxy.toml.j2
@@ -133,7 +133,7 @@ cert_refresh_delay = 240
 ## People in China may need to use 114.114.114.114:53 here.
 
 bootstrap_resolvers = ['{{ dnscrypt_bootstrap_resolvers|join('\', \'')}}']
-# fallback_resolver = '{{ dnscrypt_fallback_resolver }}'
+fallback_resolver = '{{ dnscrypt_fallback_resolver }}'
 
 ## Never try to use the system DNS settings; unconditionally use the
 ## fallback resolver.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-#dnscrypt_arch: "{{ archive: linux_arm64, dir: linux-arm64 if dnscrypt_architecture == 'linux-arm64' }}"
+# dnscrypt_arch: "{{ archive: linux_arm64, dir: linux-arm64 if dnscrypt_architecture == 'linux-arm64' }}"


### PR DESCRIPTION
* remove privilege exhalation from tasks:
   * the role must be called with specific `become: yes` attribute to provide it the required privileges
* Add role variables:
  * `dnscrypt_anonymizer_server_names`
  * `dnscrypt_bootstrap_resolvers`
  * `dnscrypt_cache_size`
  * `dnscrypt_cache_min_ttl`
  * `dnscrypt_ignore_system_dns`
  * `dnscrypt_netprobe_timeout`
  * `dnscrypt_netprobe_address`
  * `dnscrypt_timeout`
* update the `dnscrypt-proxy.toml.j2` template to
   * support new variables
   * support [sources.'relays']
* updates `yes` to `true` to respect Ansible suggested standards
* make use of `dnscrypt_bootstrap_resolvers` instead of `dnscrypt_fallback_resolver`
  * `dnscrypt_fallback_resolver` is deprecated
  * for backward compatibility `dnscrypt_fallback_resolver` is sourced from the first value of `dnscrypt_bootstrap_resolvers`
  * rewrote a few tasks
     * use Verbose YAML Format instead of Shorthand Syntax (to comply with recommended way to write Ansible tasks)
     * use Fully Qualified Names for modules
* grouped tasks with the same `tags` and/ot `when` attributes in Blocks
* rewrote the Pi-Hole tasks to allow the handling of multiple DNS servers
   * in case the Pi-Hole was pre-configured to use other local local DNS services the dnscrypt-proxy address is placed as first server
* update README formatting